### PR TITLE
Add liquibase definition to top of file

### DIFF
--- a/apps/db/tables/Account.sql
+++ b/apps/db/tables/Account.sql
@@ -1,3 +1,5 @@
+--liquibase formatted sql
+
 --changeset sean.vanwyk:account:1
 CREATE TABLE "Account" (
   "AccountID" serial PRIMARY KEY,

--- a/apps/db/tables/Config.sql
+++ b/apps/db/tables/Config.sql
@@ -1,3 +1,5 @@
+--liquibase formatted sql
+
 --changeset sean.vanwyk:config:1
 CREATE TABLE "Config" (
   "ConfigID" serial PRIMARY KEY,

--- a/apps/db/tables/Fertilizer.sql
+++ b/apps/db/tables/Fertilizer.sql
@@ -1,3 +1,5 @@
+--liquibase formatted sql
+
 --changeset sean.vanwyk:fertilizer:1
 CREATE TABLE "FertilizerType" (
   "FertilizerTypeID" serial PRIMARY KEY,

--- a/apps/db/tables/GrowZone.sql
+++ b/apps/db/tables/GrowZone.sql
@@ -1,3 +1,5 @@
+--liquibase formatted sql
+
 --changeset sean.vanwyk:growzone:1
 CREATE TABLE "GrowZone" (
   "GrowZoneID" serial PRIMARY KEY,

--- a/apps/db/tables/Plot.sql
+++ b/apps/db/tables/Plot.sql
@@ -1,3 +1,5 @@
+--liquibase formatted sql
+
 --changeset sean.vanwyk:plot:1
 CREATE TABLE "Plot" (
   "PlotID" serial PRIMARY KEY,

--- a/apps/db/tables/PlotData.sql
+++ b/apps/db/tables/PlotData.sql
@@ -1,3 +1,5 @@
+--liquibase formatted sql
+
 --changeset sean.vanwyk:plotdata:1
 CREATE TABLE "PlotData" (
   "PlotDataID" serial PRIMARY KEY,

--- a/apps/db/tables/PlotType.sql
+++ b/apps/db/tables/PlotType.sql
@@ -1,3 +1,5 @@
+--liquibase formatted sql
+
 --changeset sean.vanwyk:plottype:1
 CREATE TABLE "PlotType" (
   "PlotTypeID" serial PRIMARY KEY,

--- a/apps/db/tables/Produce.sql
+++ b/apps/db/tables/Produce.sql
@@ -1,3 +1,5 @@
+--liquibase formatted sql
+
 --changeset sean.vanwyk:produce:1
 CREATE TABLE "Produce" (
   "ProduceID" serial PRIMARY KEY,

--- a/apps/db/tables/ProduceType.sql
+++ b/apps/db/tables/ProduceType.sql
@@ -1,3 +1,5 @@
+--liquibase formatted sql
+
 --changeset sean.vanwyk:producetype:1
 CREATE TABLE "ProduceType" (
   "ProduceTypeID" serial PRIMARY KEY,

--- a/apps/db/tables/Region.sql
+++ b/apps/db/tables/Region.sql
@@ -1,3 +1,5 @@
+--liquibase formatted sql
+
 --changeset sean.vanwyk:region:1
 CREATE TABLE "Region" (
   "RegionID" serial PRIMARY KEY,


### PR DESCRIPTION
# Description

During my initial setup of liquibase, I see you're supposed to set each file as liquibase formatted. Previously the changes weren't running individually by each changeset.

This WILL break the liquibase CI/CD, and should probably have the database dropped and recreated before merging. However, apart from this mistake, we now shouldn't need to have to restart it again (oops)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update