### PR TITLE
Snake Case for Database

### DIFF
--- a/apps/db/tables/Account.sql
+++ b/apps/db/tables/Account.sql
@@ -1,8 +1,8 @@
 --liquibase formatted sql
 
 --changeset sean.vanwyk:account:1
-CREATE TABLE "Account" (
-  "AccountID" serial PRIMARY KEY,
-  "AccountUID" varchar NOT NULL
+CREATE TABLE account (
+  accountid serial PRIMARY KEY,
+  account_uid varchar NOT NULL
 );
---rollback DROP TABLE "Account";
+--rollback DROP TABLE account;

--- a/apps/db/tables/Config.sql
+++ b/apps/db/tables/Config.sql
@@ -1,20 +1,20 @@
 --liquibase formatted sql
 
 --changeset sean.vanwyk:config:1
-CREATE TABLE "Config" (
-  "ConfigID" serial PRIMARY KEY,
-  "ConfigName" varchar NOT NULL,
-  "Description" varchar NOT NULL,
-  "AccountID" integer,
-  "FertilizerTypeID" integer NOT NULL,
-  "WaterPerHour" numeric NOT NULL
+CREATE TABLE config (
+  configid serial PRIMARY KEY,
+  config_name varchar NOT NULL,
+  description varchar NOT NULL,
+  accountid integer,
+  fertilizertypeid integer NOT NULL,
+  water_per_hour numeric NOT NULL
 );
---rollback DROP TABLE "Config";
+--rollback DROP TABLE config;
 
 --changeset sean.vanwyk:config:2
-ALTER TABLE "Config" ADD CONSTRAINT "Config_FertilizerTypeID_FK" FOREIGN KEY ("FertilizerTypeID") REFERENCES "FertilizerType" ("FertilizerTypeID");
---rollback ALTER TABLE "Config" DROP CONSTRAINT "Config_FertilizerTypeID_FK";
+ALTER TABLE config ADD CONSTRAINT "Config_FertilizerTypeID_FK" FOREIGN KEY (fertilizertypeid) REFERENCES fertilizer_type (fertilizertypeid);
+--rollback ALTER TABLE config DROP CONSTRAINT "Config_FertilizerTypeID_FK";
 
 --changeset sean.vanwyk:config:3
-ALTER TABLE "Config" ADD CONSTRAINT "Config_AccountID_FK" FOREIGN KEY ("AccountID") REFERENCES "Account" ("AccountID");
---rollback ALTER TABLE "Config" DROP CONSTRAINT "Config_AccountID_FK";
+ALTER TABLE config ADD CONSTRAINT "Config_AccountID_FK" FOREIGN KEY (accountid) REFERENCES account (accountid);
+--rollback ALTER TABLE config DROP CONSTRAINT "Config_AccountID_FK";

--- a/apps/db/tables/Config.sql
+++ b/apps/db/tables/Config.sql
@@ -6,13 +6,13 @@ CREATE TABLE config (
   config_name varchar NOT NULL,
   description varchar NOT NULL,
   accountid integer,
-  fertilizertypeid integer NOT NULL,
+  fertilizer_typeid integer NOT NULL,
   water_per_hour numeric NOT NULL
 );
 --rollback DROP TABLE config;
 
 --changeset sean.vanwyk:config:2
-ALTER TABLE config ADD CONSTRAINT "Config_FertilizerTypeID_FK" FOREIGN KEY (fertilizertypeid) REFERENCES fertilizer_type (fertilizertypeid);
+ALTER TABLE config ADD CONSTRAINT "Config_FertilizerTypeID_FK" FOREIGN KEY (fertilizer_typeid) REFERENCES fertilizer_type (fertilizertypeid);
 --rollback ALTER TABLE config DROP CONSTRAINT "Config_FertilizerTypeID_FK";
 
 --changeset sean.vanwyk:config:3

--- a/apps/db/tables/Config.sql
+++ b/apps/db/tables/Config.sql
@@ -12,7 +12,7 @@ CREATE TABLE config (
 --rollback DROP TABLE config;
 
 --changeset sean.vanwyk:config:2
-ALTER TABLE config ADD CONSTRAINT "Config_FertilizerTypeID_FK" FOREIGN KEY (fertilizer_typeid) REFERENCES fertilizer_type (fertilizertypeid);
+ALTER TABLE config ADD CONSTRAINT "Config_FertilizerTypeID_FK" FOREIGN KEY (fertilizer_typeid) REFERENCES fertilizer_type (fertilizer_typeid);
 --rollback ALTER TABLE config DROP CONSTRAINT "Config_FertilizerTypeID_FK";
 
 --changeset sean.vanwyk:config:3

--- a/apps/db/tables/Config.sql
+++ b/apps/db/tables/Config.sql
@@ -20,5 +20,5 @@ ALTER TABLE config ADD CONSTRAINT "Config_AccountID_FK" FOREIGN KEY (accountid) 
 --rollback ALTER TABLE config DROP CONSTRAINT "Config_AccountID_FK";
 
 --changeset sean.vanwyk:config:4
-ALTER TABLE "Config" ADD CONSTRAINT "Config_PositiveWaterPerHour" CHECK (water_per_hour >= 0);
---rollback ALTER TABLE "Config" DROP CONSTRAINT "Config_PositiveWaterPerHour";
+ALTER TABLE config ADD CONSTRAINT "Config_PositiveWaterPerHour" CHECK (water_per_hour >= 0);
+--rollback ALTER TABLE config DROP CONSTRAINT "Config_PositiveWaterPerHour";

--- a/apps/db/tables/Fertilizer.sql
+++ b/apps/db/tables/Fertilizer.sql
@@ -1,8 +1,0 @@
---liquibase formatted sql
-
---changeset sean.vanwyk:fertilizer:1
-CREATE TABLE "FertilizerType" (
-  "FertilizerTypeID" serial PRIMARY KEY,
-  "FertilizerType" varchar NOT NULL
-);
---rollback DROP TABLE "FertilizerType";

--- a/apps/db/tables/FertilizerType.sql
+++ b/apps/db/tables/FertilizerType.sql
@@ -2,7 +2,7 @@
 
 --changeset sean.vanwyk:fertilizer:1
 CREATE TABLE fertilizer_type (
-  fertilizertypeid serial PRIMARY KEY,
+  fertilizer_typeid serial PRIMARY KEY,
   fertilizer_type varchar NOT NULL
 );
 --rollback DROP TABLE fertilizer_type;

--- a/apps/db/tables/FertilizerType.sql
+++ b/apps/db/tables/FertilizerType.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+
+--changeset sean.vanwyk:fertilizer:1
+CREATE TABLE fertilizer_type (
+  fertilizertypeid serial PRIMARY KEY,
+  fertilizer_type varchar NOT NULL
+);
+--rollback DROP TABLE fertilizer_type;

--- a/apps/db/tables/GrowZone.sql
+++ b/apps/db/tables/GrowZone.sql
@@ -2,8 +2,8 @@
 
 --changeset sean.vanwyk:growzone:1
 CREATE TABLE grow_zone (
-  growzoneid serial PRIMARY KEY,
-  growzone_name varchar NOT NULL,
+  grow_zoneid serial PRIMARY KEY,
+  grow_zone_name varchar NOT NULL,
   regionid integer NOT NULL
 );
 --rollback DROP TABLE grow_zone;

--- a/apps/db/tables/GrowZone.sql
+++ b/apps/db/tables/GrowZone.sql
@@ -1,13 +1,13 @@
 --liquibase formatted sql
 
 --changeset sean.vanwyk:growzone:1
-CREATE TABLE "GrowZone" (
-  "GrowZoneID" serial PRIMARY KEY,
-  "GrowZoneName" varchar NOT NULL,
-  "RegionID" integer NOT NULL
+CREATE TABLE grow_zone (
+  growzoneid serial PRIMARY KEY,
+  growzone_name varchar NOT NULL,
+  regionid integer NOT NULL
 );
---rollback DROP TABLE "GrowZone";
+--rollback DROP TABLE grow_zone;
 
 --changeset sean.vanwyk:growzone:2
-ALTER TABLE "GrowZone" ADD CONSTRAINT "GrowZone_RegionID_FK" FOREIGN KEY ("RegionID") REFERENCES "Region" ("RegionID");
---rollback ALTER TABLE "GrowZone" DROP CONSTRAINT "GrowZone_RegionID_FK";
+ALTER TABLE grow_zone ADD CONSTRAINT "GrowZone_RegionID_FK" FOREIGN KEY (regionid) REFERENCES region (regionid);
+--rollback ALTER TABLE grow_zone DROP CONSTRAINT "GrowZone_RegionID_FK";

--- a/apps/db/tables/Plot.sql
+++ b/apps/db/tables/Plot.sql
@@ -6,8 +6,8 @@ CREATE TABLE plot (
   plot_name varchar NOT NULL,
   description varchar NOT NULL,
   accountid integer NOT NULL,
-  growzoneid integer NOT NULL,
-  plottypeid integer NOT NULL,
+  grow_zoneid integer NOT NULL,
+  plot_typeid integer NOT NULL,
   configid integer NOT NULL,
   creation_date timestamp NOT NULL,
   terminated boolean NOT NULL

--- a/apps/db/tables/Plot.sql
+++ b/apps/db/tables/Plot.sql
@@ -1,31 +1,31 @@
 --liquibase formatted sql
 
 --changeset sean.vanwyk:plot:1
-CREATE TABLE "Plot" (
-  "PlotID" serial PRIMARY KEY,
-  "PlotName" varchar NOT NULL,
-  "Description" varchar NOT NULL,
-  "AccountID" integer NOT NULL,
-  "GrowZoneID" integer NOT NULL,
-  "PlotTypeID" integer NOT NULL,
-  "ConfigID" integer NOT NULL,
-  "CreationDate" timestamp NOT NULL,
-  "Terminated" boolean NOT NULL
+CREATE TABLE plot (
+  plotid serial PRIMARY KEY,
+  plot_name varchar NOT NULL,
+  description varchar NOT NULL,
+  accountid integer NOT NULL,
+  growzoneid integer NOT NULL,
+  plottypeid integer NOT NULL,
+  configid integer NOT NULL,
+  creation_date timestamp NOT NULL,
+  terminated boolean NOT NULL
 );
---rollback DROP TABLE Plot;
+--rollback DROP TABLE plot;
 
 --changeset sean.vanwyk:plot:2
-ALTER TABLE "Plot" ADD CONSTRAINT "Plot_PlotTypeID_FK" FOREIGN KEY ("PlotTypeID") REFERENCES "PlotType" ("PlotTypeID");
---rollback ALTER TABLE "Plot" DROP CONSTRAINT "Plot_PlotTypeID_FK";
+ALTER TABLE plot ADD CONSTRAINT "Plot_PlotTypeID_FK" FOREIGN KEY (plottypeid) REFERENCES plot_type (plottypeid);
+--rollback ALTER TABLE plot DROP CONSTRAINT "Plot_PlotTypeID_FK";
 
 --changeset sean.vanwyk:plot:3
-ALTER TABLE "Plot" ADD CONSTRAINT "Plot_ConfigID_FK" FOREIGN KEY ("ConfigID") REFERENCES "Config" ("ConfigID");
---rollback ALTER TABLE "Plot" DROP CONSTRAINT "Plot_ConfigID_FK";
+ALTER TABLE plot ADD CONSTRAINT "Plot_ConfigID_FK" FOREIGN KEY (configid) REFERENCES config (configid);
+--rollback ALTER TABLE plot DROP CONSTRAINT "Plot_ConfigID_FK";
 
 --changeset sean.vanwyk:plot:4
-ALTER TABLE "Plot" ADD CONSTRAINT "Plot_GrowZoneID_FK" FOREIGN KEY ("GrowZoneID") REFERENCES "GrowZone" ("GrowZoneID");
---rollback ALTER TABLE "Plot" DROP CONSTRAINT "Plot_GrowZoneID_FK";
+ALTER TABLE plot ADD CONSTRAINT "Plot_GrowZoneID_FK" FOREIGN KEY (growzoneid) REFERENCES grow_zone (growzoneid);
+--rollback ALTER TABLE plot DROP CONSTRAINT "Plot_GrowZoneID_FK";
 
 --changeset sean.vanwyk:plot:5
-ALTER TABLE "Plot" ADD CONSTRAINT "Plot_AccountID_FK" FOREIGN KEY ("AccountID") REFERENCES "Account" ("AccountID");
---rollback ALTER TABLE "Plot" DROP CONSTRAINT "Plot_AccountID_FK";
+ALTER TABLE plot ADD CONSTRAINT "Plot_AccountID_FK" FOREIGN KEY (accountid) REFERENCES account (accountid);
+--rollback ALTER TABLE plot DROP CONSTRAINT "Plot_AccountID_FK";

--- a/apps/db/tables/Plot.sql
+++ b/apps/db/tables/Plot.sql
@@ -15,7 +15,7 @@ CREATE TABLE plot (
 --rollback DROP TABLE plot;
 
 --changeset sean.vanwyk:plot:2
-ALTER TABLE plot ADD CONSTRAINT "Plot_PlotTypeID_FK" FOREIGN KEY (plottypeid) REFERENCES plot_type (plottypeid);
+ALTER TABLE plot ADD CONSTRAINT "Plot_PlotTypeID_FK" FOREIGN KEY (plot_typeid) REFERENCES plot_type (plot_typeid);
 --rollback ALTER TABLE plot DROP CONSTRAINT "Plot_PlotTypeID_FK";
 
 --changeset sean.vanwyk:plot:3
@@ -23,7 +23,7 @@ ALTER TABLE plot ADD CONSTRAINT "Plot_ConfigID_FK" FOREIGN KEY (configid) REFERE
 --rollback ALTER TABLE plot DROP CONSTRAINT "Plot_ConfigID_FK";
 
 --changeset sean.vanwyk:plot:4
-ALTER TABLE plot ADD CONSTRAINT "Plot_GrowZoneID_FK" FOREIGN KEY (growzoneid) REFERENCES grow_zone (growzoneid);
+ALTER TABLE plot ADD CONSTRAINT "Plot_GrowZoneID_FK" FOREIGN KEY (grow_zoneid) REFERENCES grow_zone (grow_zoneid);
 --rollback ALTER TABLE plot DROP CONSTRAINT "Plot_GrowZoneID_FK";
 
 --changeset sean.vanwyk:plot:5

--- a/apps/db/tables/PlotData.sql
+++ b/apps/db/tables/PlotData.sql
@@ -2,7 +2,7 @@
 
 --changeset sean.vanwyk:plotdata:1
 CREATE TABLE plot_data (
-  plotdataid serial PRIMARY KEY,
+  plot_dataid serial PRIMARY KEY,
   plotid integer NOT NULL,
   growth_percent numeric NOT NULL,
   sunlight numeric NOT NULL,

--- a/apps/db/tables/PlotData.sql
+++ b/apps/db/tables/PlotData.sql
@@ -1,16 +1,16 @@
 --liquibase formatted sql
 
 --changeset sean.vanwyk:plotdata:1
-CREATE TABLE "PlotData" (
-  "PlotDataID" serial PRIMARY KEY,
-  "PlotID" integer NOT NULL,
-  "GrowthPercent" numeric NOT NULL,
-  "Sunlight" numeric NOT NULL,
-  "SoilMoisture" numeric NOT NULL,
-  "TimeTaken" timestamp NOT NULL
+CREATE TABLE plot_data (
+  plotdataid serial PRIMARY KEY,
+  plotid integer NOT NULL,
+  growth_percent numeric NOT NULL,
+  sunlight numeric NOT NULL,
+  soil_moisture numeric NOT NULL,
+  time_taken timestamp NOT NULL
 );
---rollback DROP TABLE "PlotData";
+--rollback DROP TABLE plot_data;
 
 --changeset sean.vanwyk:plotdata:2
-ALTER TABLE "PlotData" ADD CONSTRAINT "PlotData_PlotID_FK" FOREIGN KEY ("PlotID") REFERENCES "Plot" ("PlotID");
---rollback ALTER TABLE "PlotData" DROP CONSTRAINT "PlotData_PlotID_FK";
+ALTER TABLE plot_data ADD CONSTRAINT "PlotData_PlotID_FK" FOREIGN KEY (plotid) REFERENCES plot (plotid);
+--rollback ALTER TABLE plot_data DROP CONSTRAINT "PlotData_PlotID_FK";

--- a/apps/db/tables/PlotType.sql
+++ b/apps/db/tables/PlotType.sql
@@ -2,11 +2,11 @@
 
 --changeset sean.vanwyk:plottype:1
 CREATE TABLE plot_type (
-  plottypeid serial PRIMARY KEY,
+  plot_typeid serial PRIMARY KEY,
   plot_type_name varchar NOT NULL,
   plot_size numeric NOT NULL,
   produceid integer NOT NULL,
-  defaultconfigid integer NOT NULL
+  default_configid integer NOT NULL
 );
 -- rollback DROP TABLE plottype;
 
@@ -15,5 +15,5 @@ ALTER TABLE plot_type ADD CONSTRAINT "PlotType_ProduceID_FK" FOREIGN KEY (produc
 --rollback ALTER TABLE plottype DROP CONSTRAINT "PlotType_ProduceID_FK";
 
 --changeset sean.vanwyk:plottype:3
-ALTER TABLE plot_type ADD CONSTRAINT "PlotType_DefaultConfigID_FK" FOREIGN KEY (defaultconfigid) REFERENCES config (configid);
+ALTER TABLE plot_type ADD CONSTRAINT "PlotType_DefaultConfigID_FK" FOREIGN KEY (default_configid) REFERENCES config (configid);
 --rollback ALTER TABLE plottype DROP CONSTRAINT "PlotType_DefaultConfigID_FK";

--- a/apps/db/tables/PlotType.sql
+++ b/apps/db/tables/PlotType.sql
@@ -1,19 +1,19 @@
 --liquibase formatted sql
 
 --changeset sean.vanwyk:plottype:1
-CREATE TABLE "PlotType" (
-  "PlotTypeID" serial PRIMARY KEY,
-  "PlotTypeName" varchar NOT NULL,
-  "PlotSize" numeric NOT NULL,
-  "ProduceID" integer NOT NULL,
-  "DefaultConfigID" integer NOT NULL
+CREATE TABLE plot_type (
+  plottypeid serial PRIMARY KEY,
+  plot_type_name varchar NOT NULL,
+  plot_size numeric NOT NULL,
+  produceid integer NOT NULL,
+  defaultconfigid integer NOT NULL
 );
--- rollback DROP TABLE "PlotType";
+-- rollback DROP TABLE plottype;
 
 --changeset sean.vanwyk:plottype:2
-ALTER TABLE "PlotType" ADD CONSTRAINT "PlotType_ProduceID_FK" FOREIGN KEY ("ProduceID") REFERENCES "Produce" ("ProduceID");
---rollback ALTER TABLE "PlotType" DROP CONSTRAINT "PlotType_ProduceID_FK";
+ALTER TABLE plot_type ADD CONSTRAINT "PlotType_ProduceID_FK" FOREIGN KEY (produceid) REFERENCES produce (produceid);
+--rollback ALTER TABLE plottype DROP CONSTRAINT "PlotType_ProduceID_FK";
 
 --changeset sean.vanwyk:plottype:3
-ALTER TABLE "PlotType" ADD CONSTRAINT "PlotType_DefaultConfigID_FK" FOREIGN KEY ("DefaultConfigID") REFERENCES "Config" ("ConfigID");
---rollback ALTER TABLE "Config" DROP CONSTRAINT "PlotType_DefaultConfigID_FK";
+ALTER TABLE plot_type ADD CONSTRAINT "PlotType_DefaultConfigID_FK" FOREIGN KEY (defaultconfigid) REFERENCES config (configid);
+--rollback ALTER TABLE plottype DROP CONSTRAINT "PlotType_DefaultConfigID_FK";

--- a/apps/db/tables/Produce.sql
+++ b/apps/db/tables/Produce.sql
@@ -9,5 +9,5 @@ CREATE TABLE produce (
 -- rollback DROP TABLE produce;
 
 --changeset sean.vanwyk:produce:2
-ALTER TABLE produce ADD CONSTRAINT "Produce_ProduceTypeID_FK" FOREIGN KEY (produce_typeid) REFERENCES produce_type (producetypeid);
+ALTER TABLE produce ADD CONSTRAINT "Produce_ProduceTypeID_FK" FOREIGN KEY (produce_typeid) REFERENCES produce_type (produce_typeid);
 --rollback ALTER TABLE produce DROP CONSTRAINT "Produce_ProduceTypeID_FK";

--- a/apps/db/tables/Produce.sql
+++ b/apps/db/tables/Produce.sql
@@ -1,13 +1,13 @@
 --liquibase formatted sql
 
 --changeset sean.vanwyk:produce:1
-CREATE TABLE "Produce" (
-  "ProduceID" serial PRIMARY KEY,
-  "ProduceName" varchar NOT NULL,
-  "ProduceTypeID" integer NOT NULL
+CREATE TABLE produce (
+  produceid serial PRIMARY KEY,
+  produce_name varchar NOT NULL,
+  producetypeid integer NOT NULL
 );
--- rollback DROP TABLE "Produce";
+-- rollback DROP TABLE produce;
 
 --changeset sean.vanwyk:produce:2
-ALTER TABLE "Produce" ADD CONSTRAINT "Produce_ProduceTypeID_FK" FOREIGN KEY ("ProduceTypeID") REFERENCES "ProduceType" ("ProduceTypeID");
---rollback ALTER TABLE "Produce" DROP CONSTRAINT "Produce_ProduceTypeID_FK";
+ALTER TABLE produce ADD CONSTRAINT "Produce_ProduceTypeID_FK" FOREIGN KEY (producetypeid) REFERENCES produce_type (producetypeid);
+--rollback ALTER TABLE produce DROP CONSTRAINT "Produce_ProduceTypeID_FK";

--- a/apps/db/tables/Produce.sql
+++ b/apps/db/tables/Produce.sql
@@ -4,10 +4,10 @@
 CREATE TABLE produce (
   produceid serial PRIMARY KEY,
   produce_name varchar NOT NULL,
-  producetypeid integer NOT NULL
+  produce_typeid integer NOT NULL
 );
 -- rollback DROP TABLE produce;
 
 --changeset sean.vanwyk:produce:2
-ALTER TABLE produce ADD CONSTRAINT "Produce_ProduceTypeID_FK" FOREIGN KEY (producetypeid) REFERENCES produce_type (producetypeid);
+ALTER TABLE produce ADD CONSTRAINT "Produce_ProduceTypeID_FK" FOREIGN KEY (produce_typeid) REFERENCES produce_type (producetypeid);
 --rollback ALTER TABLE produce DROP CONSTRAINT "Produce_ProduceTypeID_FK";

--- a/apps/db/tables/ProduceType.sql
+++ b/apps/db/tables/ProduceType.sql
@@ -2,7 +2,7 @@
 
 --changeset sean.vanwyk:producetype:1
 CREATE TABLE produce_type (
-  producetypeid serial PRIMARY KEY,
+  produce_typeid serial PRIMARY KEY,
   produce_type varchar NOT NULL
 );
 --rollback DROP TABLE produce_type;

--- a/apps/db/tables/ProduceType.sql
+++ b/apps/db/tables/ProduceType.sql
@@ -1,8 +1,8 @@
 --liquibase formatted sql
 
 --changeset sean.vanwyk:producetype:1
-CREATE TABLE "ProduceType" (
-  "ProduceTypeID" serial PRIMARY KEY,
-  "ProduceType" varchar NOT NULL
+CREATE TABLE produce_type (
+  producetypeid serial PRIMARY KEY,
+  produce_type varchar NOT NULL
 );
---rollback DROP TABLE "ProduceType";
+--rollback DROP TABLE produce_type;

--- a/apps/db/tables/Region.sql
+++ b/apps/db/tables/Region.sql
@@ -1,8 +1,8 @@
 --liquibase formatted sql
 
 --changeset sean.vanwyk:region:1
-CREATE TABLE "Region" (
-  "RegionID" serial PRIMARY KEY,
-  "RegionName" varchar NOT NULL
+CREATE TABLE region (
+  regionid serial PRIMARY KEY,
+  region_name varchar NOT NULL
 );
---rollback DROP TABLE "Region";
+--rollback DROP TABLE region;

--- a/root-changelog.yaml
+++ b/root-changelog.yaml
@@ -2,7 +2,7 @@ databaseChangeLog:
     - include:
         file: ./apps/db/tables/Account.sql    
     - include:
-        file: ./apps/db/tables/Fertilizer.sql
+        file: ./apps/db/tables/FertilizerType.sql
     - include:
         file: ./apps/db/tables/ProduceType.sql  
     - include:


### PR DESCRIPTION
# Description

Updates the database to use snake_case for naming columns and tables. Requires a DB clean.

`default_configid` is a little bit suspect, but we won't know for sure until we run into that problem.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update