### PR TITLE
Config API

### DIFF
--- a/apps/api/src/main/java/com/agricloud/controller/ConfigController.java
+++ b/apps/api/src/main/java/com/agricloud/controller/ConfigController.java
@@ -36,7 +36,7 @@ public class ConfigController {
 
     }
 
-    @PutMapping("edit")
+    @PostMapping("/edit")
     public GeneralResponse edit (@RequestBody ConfigModel config) {
         return configService.editConfig(config);
     }

--- a/apps/api/src/main/java/com/agricloud/controller/ConfigController.java
+++ b/apps/api/src/main/java/com/agricloud/controller/ConfigController.java
@@ -26,12 +26,12 @@ public class ConfigController {
     public GeneralResponse getAll() {
         return configService.getAllConfigs();
     }
-    
+
     @GetMapping("/{id}/info")
     public GeneralResponse info (@PathVariable(value = "id") Integer configID) {
         return configService.getConfigById(configID);
     }
-    
+
     @PutMapping("/create")
     public GeneralResponse create (@RequestBody ConfigModel config) {
         return configService.createConfig(config);
@@ -44,8 +44,8 @@ public class ConfigController {
     }
 
     @PutMapping("edit")
-    public GeneralResponse putMethodName(@RequestBody ConfigModel config) {
+    public GeneralResponse edit (@RequestBody ConfigModel config) {
         return configService.editConfig(config);
     }
-    
+
 }

--- a/apps/api/src/main/java/com/agricloud/controller/ConfigController.java
+++ b/apps/api/src/main/java/com/agricloud/controller/ConfigController.java
@@ -22,9 +22,9 @@ public class ConfigController {
     @Autowired
     ConfigService configService;
 
-    @GetMapping("")
-    public GeneralResponse getAll() {
-        return configService.getAllConfigs();
+    @GetMapping("/user/{user}")
+    public GeneralResponse getAll(@PathVariable(value = "user") Integer userID) {
+        return configService.getAllUserConfigs(userID);
     }
 
     @GetMapping("/{id}/info")
@@ -37,7 +37,7 @@ public class ConfigController {
         return configService.createConfig(config);
     }
 
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/{id}/delete")
     public GeneralResponse delete (@PathVariable(value = "id") Integer configID) {
         return configService.deleteConfig(configID);
 

--- a/apps/api/src/main/java/com/agricloud/controller/ConfigController.java
+++ b/apps/api/src/main/java/com/agricloud/controller/ConfigController.java
@@ -43,8 +43,8 @@ public class ConfigController {
     }
 
     @PutMapping("edit")
-    public GeneralResponse putMethodName(@RequestBody String entity) {
-        return new GeneralResponse("NOT IMPLEMENTED", null);
+    public GeneralResponse putMethodName(@RequestBody ConfigModel config) {
+        return configService.editConfig(config);
     }
     
 }

--- a/apps/api/src/main/java/com/agricloud/controller/ConfigController.java
+++ b/apps/api/src/main/java/com/agricloud/controller/ConfigController.java
@@ -1,5 +1,8 @@
 package com.agricloud.controller;
 
+import com.agricloud.model.ConfigModel;
+import com.agricloud.service.ConfigService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,17 +16,25 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 
 @RestController
-@RequestMapping("/config")
+@RequestMapping("/configs")
 public class ConfigController {
+
+    @Autowired
+    ConfigService configService;
+
+    @GetMapping("")
+    public GeneralResponse getAll() {
+        return configService.getAllConfigs();
+    }
     
-    @GetMapping("/{name}/info")
-    public GeneralResponse info (@PathVariable(value = "name") String configName) {
-        return new GeneralResponse("NOT IMPLEMENTED", null);
+    @GetMapping("/{id}/info")
+    public GeneralResponse info (@PathVariable(value = "id") Integer configID) {
+        return configService.getConfigById(configID);
     }
     
     @PutMapping("/create")
-    public GeneralResponse create (@RequestBody String entity) {
-        return new GeneralResponse("NOT IMPLEMENTED", null);
+    public GeneralResponse create (@RequestBody ConfigModel config) {
+        return configService.createConfig(config);
     }
 
     @DeleteMapping("/{name}") 

--- a/apps/api/src/main/java/com/agricloud/controller/ConfigController.java
+++ b/apps/api/src/main/java/com/agricloud/controller/ConfigController.java
@@ -37,9 +37,10 @@ public class ConfigController {
         return configService.createConfig(config);
     }
 
-    @DeleteMapping("/{name}") 
-    public GeneralResponse delete (@PathVariable(value = "name") String configName) {
-        return new GeneralResponse("NOT IMPLEMENTED", null);
+    @DeleteMapping("/{id}")
+    public GeneralResponse delete (@PathVariable(value = "id") Integer configID) {
+        return configService.deleteConfig(configID);
+
     }
 
     @PutMapping("edit")

--- a/apps/api/src/main/java/com/agricloud/controller/ConfigController.java
+++ b/apps/api/src/main/java/com/agricloud/controller/ConfigController.java
@@ -3,16 +3,9 @@ package com.agricloud.controller;
 import com.agricloud.model.ConfigModel;
 import com.agricloud.service.ConfigService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.agricloud.response.GeneralResponse;
-
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 
 
 @RestController
@@ -32,7 +25,7 @@ public class ConfigController {
         return configService.getConfigById(configID);
     }
 
-    @PutMapping("/create")
+    @PostMapping("/create")
     public GeneralResponse create (@RequestBody ConfigModel config) {
         return configService.createConfig(config);
     }

--- a/apps/api/src/main/java/com/agricloud/model/ConfigModel.java
+++ b/apps/api/src/main/java/com/agricloud/model/ConfigModel.java
@@ -1,0 +1,26 @@
+package com.agricloud.model;
+
+import jakarta.annotation.Nonnull;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Entity
+@Data
+@Table(name = "config")
+@NoArgsConstructor
+public class ConfigModel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer configID;
+
+    @Nonnull private String configName;
+    @Nonnull private String description;
+    private Integer accountID;
+    @Nonnull private Integer fertilizerTypeID;
+    @Nonnull private BigDecimal waterPerHour;
+
+}

--- a/apps/api/src/main/java/com/agricloud/repository/ConfigRepository.java
+++ b/apps/api/src/main/java/com/agricloud/repository/ConfigRepository.java
@@ -3,7 +3,9 @@ package com.agricloud.repository;
 import com.agricloud.model.ConfigModel;
 import org.springframework.data.repository.CrudRepository;
 
-public interface ConfigRepository extends CrudRepository<ConfigModel, Integer> {
+import java.util.List;
 
+public interface ConfigRepository extends CrudRepository<ConfigModel, Integer> {
+    List<ConfigModel> findAllByAccountIDOrAccountIDIsNull(Integer accountID);
     ConfigModel findConfigByConfigID(Integer configID);
 }

--- a/apps/api/src/main/java/com/agricloud/repository/ConfigRepository.java
+++ b/apps/api/src/main/java/com/agricloud/repository/ConfigRepository.java
@@ -1,0 +1,9 @@
+package com.agricloud.repository;
+
+import com.agricloud.model.ConfigModel;
+import org.springframework.data.repository.CrudRepository;
+
+public interface ConfigRepository extends CrudRepository<ConfigModel, Integer> {
+
+    ConfigModel findConfigByConfigID(Integer configID);
+}

--- a/apps/api/src/main/java/com/agricloud/repository/PlotRepository.java
+++ b/apps/api/src/main/java/com/agricloud/repository/PlotRepository.java
@@ -4,4 +4,9 @@ import org.springframework.data.repository.CrudRepository;
 
 import com.agricloud.model.PlotModel;
 
-public interface PlotRepository extends CrudRepository<PlotModel, Integer> {}
+import java.util.List;
+
+public interface PlotRepository extends CrudRepository<PlotModel, Integer> {
+
+    List<PlotModel> findPlotModelsByConfigID(Integer configID);
+}

--- a/apps/api/src/main/java/com/agricloud/service/ConfigService.java
+++ b/apps/api/src/main/java/com/agricloud/service/ConfigService.java
@@ -18,10 +18,11 @@ public class ConfigService {
     @Autowired
     private PlotRepository plotRepository;
 
-    public GeneralResponse getAllConfigs() {
+    public GeneralResponse getAllUserConfigs(Integer accountID) {
         GeneralResponse response = new GeneralResponse();
         try {
-            Iterable<ConfigModel> configs = configRepository.findAll();
+            Iterable<ConfigModel> configs = configRepository.findAllByAccountIDOrAccountIDIsNull(accountID);
+
             response.setBody(configs);
             response.setStatus("Success");
         } catch (Exception e) {

--- a/apps/api/src/main/java/com/agricloud/service/ConfigService.java
+++ b/apps/api/src/main/java/com/agricloud/service/ConfigService.java
@@ -1,0 +1,56 @@
+package com.agricloud.service;
+
+import com.agricloud.model.ConfigModel;
+import com.agricloud.repository.ConfigRepository;
+import com.agricloud.response.GeneralResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+
+@Service
+public class ConfigService {
+
+    @Autowired
+    ConfigRepository configRepository;
+
+    public GeneralResponse getAllConfigs() {
+        GeneralResponse response = new GeneralResponse();
+        try {
+            Iterable<ConfigModel> configs = configRepository.findAll();
+            response.setBody(configs);
+            response.setStatus("Success");
+        } catch (Exception e) {
+            response.setStatus("Failure");
+        }
+        return response;
+    }
+
+    public GeneralResponse getConfigById(Integer configID) {
+        GeneralResponse response = new GeneralResponse();
+        try {
+            ConfigModel config = configRepository.findConfigByConfigID(configID);
+            if (config == null) {
+                response.setStatus("Not Found");
+            } else {
+                response.setStatus("Found");
+                response.setBody(config);
+            }
+        } catch (Exception e) {
+            response.setStatus("FAILURE");
+        }
+        return response;
+    }
+
+    public GeneralResponse createConfig(ConfigModel config) {
+        GeneralResponse response = new GeneralResponse();
+        try {
+            configRepository.save(config);
+            response.setStatus("Success");
+            response.setBody(config);
+        } catch (Exception e) {
+            response.setStatus("FAILURE");
+            response.setBody(e);
+        }
+        return response;
+    }
+}

--- a/apps/api/src/main/java/com/agricloud/service/ConfigService.java
+++ b/apps/api/src/main/java/com/agricloud/service/ConfigService.java
@@ -2,6 +2,7 @@ package com.agricloud.service;
 
 import com.agricloud.model.ConfigModel;
 import com.agricloud.repository.ConfigRepository;
+import com.agricloud.repository.PlotRepository;
 import com.agricloud.response.GeneralResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -14,6 +15,8 @@ public class ConfigService {
 
     @Autowired
     ConfigRepository configRepository;
+    @Autowired
+    private PlotRepository plotRepository;
 
     public GeneralResponse getAllConfigs() {
         GeneralResponse response = new GeneralResponse();
@@ -52,6 +55,32 @@ public class ConfigService {
         } catch (Exception e) {
             response.setStatus("FAILURE");
             response.setBody(e);
+        }
+        return response;
+    }
+
+    public GeneralResponse deleteConfig(Integer configID) {
+        GeneralResponse response = new GeneralResponse();
+        try {
+            ConfigModel config = configRepository.findConfigByConfigID(configID);
+            if (config == null) {
+                response.setStatus("Not Found");
+                return response;
+            }
+
+            // TODO: Propagate changes to Plots using this plot to revert to defaultconfig
+            // TODO: Check that the config isn't in use as a defaultconfig
+
+            // Ensure config isn't in use.
+            if (!plotRepository.findPlotModelsByConfigID(configID).isEmpty()) {
+                response.setStatus("Config in Use");
+            } else {
+                configRepository.delete(config);
+                response.setStatus("Deleted");
+                response.setBody(config);
+            }
+        } catch (Exception e) {
+            response.setStatus("FAILURE");
         }
         return response;
     }

--- a/apps/api/src/main/java/com/agricloud/service/ConfigService.java
+++ b/apps/api/src/main/java/com/agricloud/service/ConfigService.java
@@ -86,6 +86,10 @@ public class ConfigService {
         try {
             Optional<ConfigModel> config2Optional = configRepository.findById(config.getConfigID());
             config2Optional.ifPresentOrElse(config2 -> {
+//                 if (accountID != config2.getAccountID()) {
+//                     response.setStatus("You are not permitted to edit this config");
+//                     return response;
+//                }
                 configRepository.save(config);
                 response.setStatus("Successfully edited config");
                 response.setBody(config);

--- a/apps/api/src/main/java/com/agricloud/service/ConfigService.java
+++ b/apps/api/src/main/java/com/agricloud/service/ConfigService.java
@@ -24,9 +24,9 @@ public class ConfigService {
             Iterable<ConfigModel> configs = configRepository.findAllByAccountIDOrAccountIDIsNull(accountID);
 
             response.setBody(configs);
-            response.setStatus("Success");
+            response.setStatus("Retrieved user configs");
         } catch (Exception e) {
-            response.setStatus("Failure");
+            response.setStatus("Failed to retrieve user configs");
         }
         return response;
     }
@@ -36,13 +36,13 @@ public class ConfigService {
         try {
             ConfigModel config = configRepository.findConfigByConfigID(configID);
             if (config == null) {
-                response.setStatus("Not Found");
+                response.setStatus("Found no config with that ID");
             } else {
-                response.setStatus("Found");
+                response.setStatus("Found config");
                 response.setBody(config);
             }
         } catch (Exception e) {
-            response.setStatus("FAILURE");
+            response.setStatus("Failed to get Config with ID" + configID);
         }
         return response;
     }
@@ -51,10 +51,10 @@ public class ConfigService {
         GeneralResponse response = new GeneralResponse();
         try {
             configRepository.save(config);
-            response.setStatus("Success");
+            response.setStatus("Created config successfully");
             response.setBody(config);
         } catch (Exception e) {
-            response.setStatus("FAILURE");
+            response.setStatus("Failed to create config");
             response.setBody(e);
         }
         return response;
@@ -65,7 +65,7 @@ public class ConfigService {
         try {
             ConfigModel config = configRepository.findConfigByConfigID(configID);
             if (config == null) {
-                response.setStatus("Not Found");
+                response.setStatus("Could not find config to delete");
                 return response;
             }
 
@@ -74,14 +74,14 @@ public class ConfigService {
 
             // Ensure config isn't in use.
             if (!plotRepository.findPlotModelsByConfigID(configID).isEmpty()) {
-                response.setStatus("Config in Use");
+                response.setStatus("Config in use");
             } else {
                 configRepository.delete(config);
-                response.setStatus("Deleted");
+                response.setStatus("Deleted config successfully");
                 response.setBody(config);
             }
         } catch (Exception e) {
-            response.setStatus("FAILURE");
+            response.setStatus("Failed to delete config");
         }
         return response;
     }
@@ -91,15 +91,15 @@ public class ConfigService {
         try {
             Optional<ConfigModel> config2 = configRepository.findById(config.getConfigID());
             if (config2.isEmpty()) {
-                response.setStatus("NOT FOUND");
+                response.setStatus("Could not find config to edit");
                 response.setBody(config);
             } else {
                 configRepository.save(config);
-                response.setStatus("Success");
+                response.setStatus("Successfully edited config");
                 response.setBody(config);
             }
         } catch (Exception e) {
-            response.setStatus("FAILURE");
+            response.setStatus("Failed to edit config");
             response.setBody(e);
         }
         return response;

--- a/apps/api/src/main/java/com/agricloud/service/ConfigService.java
+++ b/apps/api/src/main/java/com/agricloud/service/ConfigService.java
@@ -6,6 +6,8 @@ import com.agricloud.response.GeneralResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 
 @Service
 public class ConfigService {
@@ -47,6 +49,25 @@ public class ConfigService {
             configRepository.save(config);
             response.setStatus("Success");
             response.setBody(config);
+        } catch (Exception e) {
+            response.setStatus("FAILURE");
+            response.setBody(e);
+        }
+        return response;
+    }
+
+    public GeneralResponse editConfig(ConfigModel config) {
+        GeneralResponse response = new GeneralResponse();
+        try {
+            Optional<ConfigModel> config2 = configRepository.findById(config.getConfigID());
+            if (config2.isEmpty()) {
+                response.setStatus("NOT FOUND");
+                response.setBody(config);
+            } else {
+                configRepository.save(config);
+                response.setStatus("Success");
+                response.setBody(config);
+            }
         } catch (Exception e) {
             response.setStatus("FAILURE");
             response.setBody(e);

--- a/apps/cli/src/main/java/com/agricloud/api/ConfigAPI.java
+++ b/apps/cli/src/main/java/com/agricloud/api/ConfigAPI.java
@@ -33,7 +33,7 @@ public class ConfigAPI {
 
     public ConfigResponse info (@PathVariable(value = "id") Integer configID) {
         try {
-            return restTemplate.getForObject(new URI(apiConfig.getEndpoint() + "/configs/info" + configID), ConfigResponse.class);
+            return restTemplate.getForObject(new URI(apiConfig.getEndpoint() + "/configs/" + configID + "/info"), ConfigResponse.class);
         } catch (RestClientException e) {
             return new ConfigResponse("Rest Error occured while making request", null);
         } catch (URISyntaxException e) {

--- a/apps/cli/src/main/java/com/agricloud/api/ConfigAPI.java
+++ b/apps/cli/src/main/java/com/agricloud/api/ConfigAPI.java
@@ -1,0 +1,77 @@
+package com.agricloud.api;
+
+import com.agricloud.config.ApiConfig;
+import com.agricloud.entity.Config;
+import com.agricloud.response.ConfigListResponse;
+import com.agricloud.response.ConfigResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+@Repository
+public class ConfigAPI {
+
+    @Autowired
+    private ApiConfig apiConfig;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public ConfigListResponse listAllFromId(Integer userID) {
+        try {
+            return restTemplate.getForObject(new URI(apiConfig.getEndpoint() + "/configs/user/" + userID), ConfigListResponse.class);
+        } catch (RestClientException e) {
+            return new ConfigListResponse("Rest Error occured while making request", null);
+        } catch (URISyntaxException e) {
+            return new ConfigListResponse("URI Error occured while making request", null);
+        }
+    }
+
+    public ConfigResponse info (@PathVariable(value = "id") Integer configID) {
+        try {
+            return restTemplate.getForObject(new URI(apiConfig.getEndpoint() + "/configs/info" + configID), ConfigResponse.class);
+        } catch (RestClientException e) {
+            return new ConfigResponse("Rest Error occured while making request", null);
+        } catch (URISyntaxException e) {
+            return new ConfigResponse("URI Error occured while making request", null);
+        }
+    }
+
+    public ConfigResponse createConfig (Config config) {
+        try {
+            return restTemplate.postForObject(new URI(apiConfig.getEndpoint() + "/configs/create"), config, ConfigResponse.class);
+        } catch (RestClientException e) {
+            return new ConfigResponse("Error occured while making request", null);
+        } catch (URISyntaxException e) {
+            return new ConfigResponse("Error occured while making request", null);
+        }
+    }
+
+    public ConfigResponse delete (Integer configID) {
+        try {
+            restTemplate.delete(new URI(apiConfig.getEndpoint() + "/configs/delete/" + configID));
+            return new ConfigResponse("Successfully deleted config", null);
+        } catch (RestClientException e) {
+            return new ConfigResponse("Error occured while making request", null);
+        } catch (URISyntaxException e) {
+            return new ConfigResponse("Error occured while making request", null);
+        }
+
+    }
+
+    @PutMapping("edit")
+    public ConfigResponse edit (Config config) {
+        try {
+            return restTemplate.postForObject(new URI(apiConfig.getEndpoint() + "/configs/edit"), config, ConfigResponse.class);
+        } catch (RestClientException e) {
+            return new ConfigResponse("Error occured while making request", null);
+        } catch (URISyntaxException e) {
+            return new ConfigResponse("Error occured while making request", null);
+        }
+    }
+
+}

--- a/apps/cli/src/main/java/com/agricloud/commands/ConfigCommands.java
+++ b/apps/cli/src/main/java/com/agricloud/commands/ConfigCommands.java
@@ -2,10 +2,8 @@ package com.agricloud.commands;
 
 import com.agricloud.service.ConfigService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.shell.standard.AbstractShellComponent;
-import org.springframework.shell.standard.ShellComponent;
-import org.springframework.shell.standard.ShellMethod;
-import org.springframework.shell.standard.ShellOption;
+import org.springframework.shell.component.ConfirmationInput;
+import org.springframework.shell.standard.*;
 
 import java.math.BigDecimal;
 
@@ -16,7 +14,7 @@ public class ConfigCommands extends AbstractShellComponent {
     ConfigService configService;
 
     @ShellMethod(key = "config create", value = "Create config")
-    public String createPlot(
+    public String configCreate(
             @ShellOption(value = "name", help = "Name of the config") String configName,
             @ShellOption(value = "desc", help = "Description of the config") String description,
             @ShellOption(value = "fertilizer-type", help = "Fertilizer used in the Config") int fertilizerTypeID,
@@ -26,9 +24,32 @@ public class ConfigCommands extends AbstractShellComponent {
     }
 
     @ShellMethod(key = "config list", value = "List your available configs")
-    public String listPlots(
+    public String configsUserList(
             @ShellOption(value = "id", help = "List available configs for the given user") int id
     ) {
         return configService.listAllFromId(id);
     }
+
+    @ShellMethod(key = "config info", value = "Get information about a config")
+    public String configInfo(
+            @ShellOption int id
+    ) {
+        return configService.infoConfig(id);
+    }
+
+    @ShellMethod(key = "config delete", value = "Delete a config")
+    public String configDelete(
+            @ShellOption int id
+    ) {
+
+        ConfirmationInput component = new ConfirmationInput(getTerminal(), "Confirm deletion of config " + id + ":");
+        component.setResourceLoader(getResourceLoader());
+        component.setTemplateExecutor(getTemplateExecutor());
+        ConfirmationInput.ConfirmationInputContext context = component.run(ConfirmationInput.ConfirmationInputContext.empty());
+        if (context.getResultValue()) {
+            return configService.deleteConfig(id);
+        }
+        return "";
+    }
+
 }

--- a/apps/cli/src/main/java/com/agricloud/commands/ConfigCommands.java
+++ b/apps/cli/src/main/java/com/agricloud/commands/ConfigCommands.java
@@ -1,0 +1,34 @@
+package com.agricloud.commands;
+
+import com.agricloud.service.ConfigService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.shell.standard.AbstractShellComponent;
+import org.springframework.shell.standard.ShellComponent;
+import org.springframework.shell.standard.ShellMethod;
+import org.springframework.shell.standard.ShellOption;
+
+import java.math.BigDecimal;
+
+@ShellComponent("Config Commands")
+public class ConfigCommands extends AbstractShellComponent {
+
+    @Autowired
+    ConfigService configService;
+
+    @ShellMethod(key = "config create", value = "Create config")
+    public String createPlot(
+            @ShellOption(value = "name", help = "Name of the config") String configName,
+            @ShellOption(value = "desc", help = "Description of the config") String description,
+            @ShellOption(value = "fertilizer-type", help = "Fertilizer used in the Config") int fertilizerTypeID,
+            @ShellOption(value = "water-per-hour", help = "Water use per hour on the config") BigDecimal waterPerHour
+    ) {
+        return configService.createConfig(configName, description, fertilizerTypeID, waterPerHour);
+    }
+
+    @ShellMethod(key = "config list", value = "List your available configs")
+    public String listPlots(
+            @ShellOption(value = "id", help = "List available configs for the given user") int id
+    ) {
+        return configService.listAllFromId(id);
+    }
+}

--- a/apps/cli/src/main/java/com/agricloud/commands/ConfigCommands.java
+++ b/apps/cli/src/main/java/com/agricloud/commands/ConfigCommands.java
@@ -17,7 +17,7 @@ public class ConfigCommands extends AbstractShellComponent {
     public String configCreate(
             @ShellOption(value = "name", help = "Name of the config") String configName,
             @ShellOption(value = "desc", help = "Description of the config") String description,
-            @ShellOption(value = "fertilizer-type", help = "Fertilizer used in the Config") int fertilizerTypeID,
+            @ShellOption(value = "fertilizer-type", help = "Fertilizer used in the config") int fertilizerTypeID,
             @ShellOption(value = "water-per-hour", help = "Water use per hour on the config") BigDecimal waterPerHour
     ) {
         return configService.createConfig(configName, description, fertilizerTypeID, waterPerHour);
@@ -50,6 +50,17 @@ public class ConfigCommands extends AbstractShellComponent {
             return configService.deleteConfig(id);
         }
         return "";
+    }
+
+    @ShellMethod(key = "config edit", value = "Edit config")
+    public String configEdit(
+            @ShellOption(value = "id", help = "ID of the config") int configID,
+            @ShellOption(value = "name", help = "Name of the config", defaultValue = ShellOption.NULL) String configName,
+            @ShellOption(value = "desc", help = "Description of the config", defaultValue = ShellOption.NULL) String description,
+            @ShellOption(value = "fertilizer-type", help = "Fertilizer used in the config", defaultValue = ShellOption.NULL) Integer fertilizerTypeID,
+            @ShellOption(value = "water-per-hour", help = "Water use per hour on the config", defaultValue = ShellOption.NULL) BigDecimal waterPerHour
+    ) {
+        return configService.editConfig(configID, configName, description, fertilizerTypeID, waterPerHour);
     }
 
 }

--- a/apps/cli/src/main/java/com/agricloud/entity/Config.java
+++ b/apps/cli/src/main/java/com/agricloud/entity/Config.java
@@ -1,0 +1,21 @@
+package com.agricloud.entity;
+
+import jakarta.annotation.Nonnull;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@NoArgsConstructor
+public class Config {
+
+    private Integer configID;
+
+    @Nonnull private String configName;
+    @Nonnull private String description;
+    private Integer accountID;
+    @Nonnull private Integer fertilizerTypeID;
+    @Nonnull private BigDecimal waterPerHour;
+
+}

--- a/apps/cli/src/main/java/com/agricloud/response/ConfigListResponse.java
+++ b/apps/cli/src/main/java/com/agricloud/response/ConfigListResponse.java
@@ -1,0 +1,17 @@
+package com.agricloud.response;
+
+import com.agricloud.entity.Config;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConfigListResponse {
+
+    private String status;
+    private List<Config> body;
+}

--- a/apps/cli/src/main/java/com/agricloud/response/ConfigResponse.java
+++ b/apps/cli/src/main/java/com/agricloud/response/ConfigResponse.java
@@ -1,0 +1,17 @@
+package com.agricloud.response;
+
+import com.agricloud.entity.Config;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConfigResponse {
+
+    private String status;
+    private Config body;
+
+}

--- a/apps/cli/src/main/java/com/agricloud/service/ConfigService.java
+++ b/apps/cli/src/main/java/com/agricloud/service/ConfigService.java
@@ -59,4 +59,24 @@ public class ConfigService {
                         (body) -> "\n\nConfig Details:" + body.toString()
                 ).orElse("");
     }
+
+    public String editConfig(int configID, String configName, String description, Integer fertilizerTypeID, BigDecimal waterPerHour) {
+        ConfigResponse existingConfigResponse = configAPI.info(configID);
+        if (!existingConfigResponse.getStatus().equals("Found config")) {
+            return existingConfigResponse.getStatus();
+        }
+        Config existingConfig = existingConfigResponse.getBody();
+        if (configName != null) existingConfig.setConfigName(configName);
+        if (description != null) existingConfig.setDescription(description);
+        if (fertilizerTypeID != null) existingConfig.setFertilizerTypeID(fertilizerTypeID);
+        if (waterPerHour != null) existingConfig.setWaterPerHour(waterPerHour);
+
+
+        ConfigResponse response = configAPI.edit(existingConfig);
+
+        return response.getStatus() + Optional.ofNullable(response.getBody())
+                .map(
+                        (body) -> "\n\nConfig Details:" + body.toString()
+                ).orElse("");
+    }
 }

--- a/apps/cli/src/main/java/com/agricloud/service/ConfigService.java
+++ b/apps/cli/src/main/java/com/agricloud/service/ConfigService.java
@@ -1,0 +1,47 @@
+package com.agricloud.service;
+
+import com.agricloud.api.ConfigAPI;
+import com.agricloud.entity.Config;
+import com.agricloud.response.ConfigListResponse;
+import com.agricloud.response.ConfigResponse;
+import com.agricloud.response.PlotResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class ConfigService {
+
+    @Autowired
+    ConfigAPI configAPI;
+
+    public String createConfig(String configName, String description, int fertilizerTypeID, BigDecimal waterPerHour) {
+        Config newConfig = new Config();
+        newConfig.setConfigName(configName);
+        newConfig.setDescription(description);
+        newConfig.setFertilizerTypeID(fertilizerTypeID);
+        newConfig.setWaterPerHour(waterPerHour);
+
+
+        ConfigResponse response = configAPI.createConfig(newConfig);
+
+        return response.getStatus() + Optional.ofNullable(response.getBody())
+                .map(
+                        (body) -> "\n\nConfig Details:" + body.toString()
+                ).orElse("");
+    }
+
+    public String listAllFromId(int id) {
+        ConfigListResponse response = configAPI.listAllFromId(id);
+        return response.getStatus() + Optional.ofNullable(response.getBody())
+                .map(
+                        (body) -> "\n\nAll Configs Details:\n" +
+                                body.stream()
+                                        .map((config -> config.getConfigID() + " - " + config.getConfigName()))
+                                        .collect(Collectors.joining("\n"))
+                ).orElse("");
+    }
+}

--- a/apps/cli/src/main/java/com/agricloud/service/ConfigService.java
+++ b/apps/cli/src/main/java/com/agricloud/service/ConfigService.java
@@ -4,7 +4,6 @@ import com.agricloud.api.ConfigAPI;
 import com.agricloud.entity.Config;
 import com.agricloud.response.ConfigListResponse;
 import com.agricloud.response.ConfigResponse;
-import com.agricloud.response.PlotResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -42,6 +41,22 @@ public class ConfigService {
                                 body.stream()
                                         .map((config -> config.getConfigID() + " - " + config.getConfigName()))
                                         .collect(Collectors.joining("\n"))
+                ).orElse("");
+    }
+
+    public String infoConfig(int id) {
+        ConfigResponse response = configAPI.info(id);
+        return response.getStatus() + Optional.ofNullable(response.getBody())
+                .map(
+                        (body) -> "\n\nConfig Details:" + body.toString()
+                ).orElse("");
+    }
+
+    public String deleteConfig(int id) {
+        ConfigResponse response = configAPI.delete(id);
+        return response.getStatus() + Optional.ofNullable(response.getBody())
+                .map(
+                        (body) -> "\n\nConfig Details:" + body.toString()
                 ).orElse("");
     }
 }


### PR DESCRIPTION
# Description

Implementation of the Config API. Deletion still requires PlotType to exist to be able to check for use in Default Config ID, but a check on the existing plots is implemented.
`GetAll` wasn't in the skeleton, but can be edited to serve all the configs you can access as a user, once we have users authenticated.

The two functions with `@RequestBody ConfigModel config` would be accessed by adding a JSON body to the API request:

```json
{
    "configName": "Test 3",
    "description": "Test 4",
    "acountID": 3,
    "fertilizerTypeID": 4,
    "waterPerHour": 12
}
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update