### PR TITLE
Implement config delete checks and update with default configID.

### DIFF
--- a/apps/api/src/main/java/com/agricloud/controller/ConfigController.java
+++ b/apps/api/src/main/java/com/agricloud/controller/ConfigController.java
@@ -30,7 +30,7 @@ public class ConfigController {
         return configService.createConfig(config);
     }
 
-    @DeleteMapping("/{id}/delete")
+    @PostMapping("/{id}/delete")
     public GeneralResponse delete (@PathVariable(value = "id") Integer configID) {
         return configService.deleteConfig(configID);
 

--- a/apps/api/src/main/java/com/agricloud/model/PlotTypeModel.java
+++ b/apps/api/src/main/java/com/agricloud/model/PlotTypeModel.java
@@ -1,0 +1,24 @@
+package com.agricloud.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@Table(name = "plot_type")
+@Entity
+@NoArgsConstructor
+public class PlotTypeModel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer plotTypeID;
+
+    private String plotTypeName;
+    private BigDecimal plotSize;
+    private Integer produceid;
+    private Integer defaultConfigid;
+
+}

--- a/apps/api/src/main/java/com/agricloud/repository/PlotTypeRepository.java
+++ b/apps/api/src/main/java/com/agricloud/repository/PlotTypeRepository.java
@@ -1,0 +1,11 @@
+package com.agricloud.repository;
+
+import com.agricloud.model.PlotTypeModel;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+
+public interface PlotTypeRepository extends CrudRepository<PlotTypeModel, Integer> {
+
+    List<PlotTypeModel> findAllByDefaultConfigid(int defaultConfigID);
+}

--- a/apps/cli/src/main/java/com/agricloud/api/ConfigAPI.java
+++ b/apps/cli/src/main/java/com/agricloud/api/ConfigAPI.java
@@ -53,8 +53,7 @@ public class ConfigAPI {
 
     public ConfigResponse delete (Integer configID) {
         try {
-            restTemplate.delete(new URI(apiConfig.getEndpoint() + "/configs/delete/" + configID));
-            return new ConfigResponse("Successfully deleted config", null);
+            return restTemplate.postForObject(new URI(apiConfig.getEndpoint() + "/configs/" + configID + "/delete"), null, ConfigResponse.class);
         } catch (RestClientException e) {
             return new ConfigResponse("Error occured while making request", null);
         } catch (URISyntaxException e) {


### PR DESCRIPTION
# Description

Ensures the config cannot be deleted if it is in use as a default config ID for defined Plot Types. If a config being deleted is in use by a plot, then update all affected plots to their default config ID.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update